### PR TITLE
Support for shared components

### DIFF
--- a/scripts/pkg-upgrade.sh
+++ b/scripts/pkg-upgrade.sh
@@ -91,7 +91,7 @@ for (( i = 0; i < $NumComponents; i++ )); do
     (( Changed++ ))
     log "Info: Upgrading $Device/$name/$version"
     if [ "$shared" == "true" ]; then
-      parent="shared"
+      parent="share"
       log "Info: $Device/$name/$version is shared"
     else
       parent="$Device"
@@ -207,6 +207,7 @@ for (( i = 0; i < $NumComponents; i++ )); do
     fi
   fi
 done
+if [ -z "$Debug" ]; then rm -rf "$TmpDir"; fi
 
 # Save a copy of the package.
 DataDir="/opt/ausocean/data"


### PR DESCRIPTION
This version of pkg-upgrade.sh supports shared components via the "shared" boolean.
For example:

```
    {
    "name": "license.txt",
    "shared": true,
    "version": "v1.0.0",
    ...
    }
```