### PR TITLE
GenerateTOTP

### DIFF
--- a/totp/totp.go
+++ b/totp/totp.go
@@ -1,0 +1,52 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2024 the Australian Ocean Lab (AusOcean). All Rights Reserved.
+
+  The Software and all intellectual property rights associated
+  therewith, including but not limited to copyrights, trademarks,
+  patents, and trade secrets, are and will remain the exclusive
+  property of the Australian Ocean Lab (AusOcean).
+*/
+
+package totp
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// GenerateTOTP generates a time-based one-time (numeric) password as
+// a string with the requested number of digits using the shared
+// secret (i.e., similar to Google Authenticator). The maximum number
+// of digits is 16, since we use SHA 256 for hashing, which returns 32
+// bytes. The supplied time is truncated (floored) to the nearest
+// minute. A common usage is to pass time.Now() as the time. However,
+// if a minute boundary is crossed between password generation and
+// password verification, the verifier may need to call GenerateTOTP
+// again using an earlier time.
+func GenerateTOTP(t time.Time, digits int, secret []byte) (string, error) {
+	const maxDigits = 16
+	if digits > maxDigits {
+		digits = maxDigits
+	}
+	t = t.Truncate(time.Minute)
+	tsBytes := []byte(strconv.Itoa(int(t.Unix())))
+	hasher := hmac.New(sha256.New, secret)
+	_, err := hasher.Write(append(secret, tsBytes...))
+	if err != nil {
+		return "", err
+	}
+	hashed := hasher.Sum(nil)
+	nonce := make([]string, digits)
+	// Emit one digit per two bytes.
+	for i := 0; i < digits; i++ {
+		nonce[i] = strconv.Itoa((int(hashed[2*i]) + int(hashed[2*i+1])) % 10)
+	}
+	return strings.Join(nonce, ""), nil
+}

--- a/totp/totp_test.go
+++ b/totp/totp_test.go
@@ -1,0 +1,63 @@
+/*
+AUTHORS
+  Alan Noble <alan@ausocean.org>
+
+LICENSE
+  Copyright (C) 2024 the Australian Ocean Lab (AusOcean). All Rights Reserved.
+
+  The Software and all intellectual property rights associated
+  therewith, including but not limited to copyrights, trademarks,
+  patents, and trade secrets, are and will remain the exclusive
+  property of the Australian Ocean Lab (AusOcean).
+*/
+
+package totp
+
+import (
+	"testing"
+	"time"
+)
+
+const secret = "not-so-secret"
+
+func TestTOTP(t *testing.T) {
+	nye2018 := time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	var tests = []struct {
+		t      time.Time
+		digits int
+		want   string
+	}{
+		{
+			digits: 10,
+			want:   "9593791354",
+		},
+		{
+			digits: 16,
+			want:   "9593791354356707",
+		},
+		{
+			t:      nye2018,
+			digits: 16,
+			want:   "6646979953861765",
+		},
+		{
+			t:      nye2018.Add(time.Duration(59) * time.Second),
+			digits: 16,
+			want:   "6646979953861765",
+		},
+	}
+
+	for i, test := range tests {
+		totp, err := GenerateTOTP(test.t, test.digits, []byte(secret))
+		if err != nil {
+			t.Fatalf("GenerateTOTP returned unexpected error: %v", err)
+		}
+		if len(totp) != test.digits {
+			t.Errorf("%d: expected %d digits, got %d", i, test.digits, len(totp))
+		}
+		if totp != test.want {
+			t.Errorf("%d: expected %s TOTP, got %s", i, test.want, totp)
+		}
+	}
+}


### PR DESCRIPTION
`GenerateTOTP` will be used to generate time-based one-time (numeric) passwords. The first application will be to generate device keys when installing a new device.