### PR TITLE
cmd/pressure-vessel: come out of alarm mode if it is safe to do so

### DIFF
--- a/cmd/pressure-vessel/main.ino
+++ b/cmd/pressure-vessel/main.ino
@@ -73,9 +73,44 @@ void flash(int n, int p) {
   }
 }
 
+void startPumpTimer(){
+  startPumpTime = millis();
+}
+
+// getPumpTime returns the pump time in minutes.
+float getPumpTime(){
+  unsigned long now = millis();
+  if (now < startPumpTime) {
+    startPumpTime = 0;
+    Serial.println("Time rolled over!");
+  }
+  return float(now-startPumpTime)/(1000.0*60.0);
+}
+
+int adjust(float p){
+  if( p < 0 ){
+    return 0;
+  }
+  return int(p);
+}
+
 bool pumpOn = false;
 unsigned long startPumpTime = 0;
 int alarmCount = 0; // Global to track alarm state entries.
+
+void setPumpState(bool state) {
+  if (state) {
+    relay(HIGH);
+    pumpOn = true;
+    startPumpTimer();
+    Serial.println("Pump turned ON.");
+  } else {
+    relay(LOW);
+    pumpOn = false;
+    Serial.println("Pump turned OFF.");
+  }
+}
+
 
 // This will put arduino into an alarm state i.e. something
 // went wrong.
@@ -178,27 +213,6 @@ void setup() {
     Serial.print("Discarding initial reading: ");
     Serial.println(reading);
   }
-}
-
-void startPumpTimer(){
-  startPumpTime = millis();
-}
-
-// getPumpTime returns the pump time in minutes.
-float getPumpTime(){
-  unsigned long now = millis();
-  if (now < startPumpTime) {
-    startPumpTime = 0;
-    Serial.println("Time rolled over!");
-  }
-  return float(now-startPumpTime)/(1000.0*60.0);
-}
-
-int adjust(float p){
-  if( p < 0 ){
-    return 0;
-  }
-  return int(p);
 }
 
 void loop() {

--- a/cmd/pressure-vessel/main.ino
+++ b/cmd/pressure-vessel/main.ino
@@ -1,6 +1,8 @@
 /*
 AUTHORS
   Saxon Nelson-Milton <saxon@ausocean.org>
+  Alan Noble <alan@ausocean.org>
+  Trek Hopton <trek@ausocean.org>
 
 LICENSE
   Copyright (C) 2020-2024 the Australian Ocean Lab (AusOcean)
@@ -73,6 +75,7 @@ void flash(int n, int p) {
   }
 }
 
+unsigned long startPumpTime = 0; // Global to track pump start time.
 void startPumpTimer(){
   startPumpTime = millis();
 }
@@ -94,8 +97,7 @@ int adjust(float p){
   return int(p);
 }
 
-bool pumpOn = false;
-unsigned long startPumpTime = 0;
+bool pumpOn = false; // Glbal to track pump state.
 int alarmCount = 0; // Global to track alarm state entries.
 
 void setPumpState(bool state) {
@@ -123,8 +125,7 @@ void alarmed(int flashes) {
   Serial.println(alarmCount);
 
   // Ensure pump is off for safety.
-  relay(LOW);
-  pumpOn = false;
+  setPumpState(false);
 
   // Stay in alarm state until timeout AND pressure is below MAX_PRESSURE.
   while (true) {
@@ -246,16 +247,13 @@ void loop() {
 
   // If the pump is on and we're above max pressure, then turn it off.
   if( pumpOn && pressure > MAX_PRESSURE ){
-    relay(LOW);
-    pumpOn = false;
+    setPumpState(false);
     MAX7219init();
   }
 
   // If pump is off but below min pressure, turn it on.
   if( !pumpOn && pressure < MIN_PRESSURE ){
-    relay(HIGH);
-    pumpOn = true;
-    startPumpTimer();
+    setPumpState(true);
     MAX7219init();
   }
 }


### PR DESCRIPTION
The program will come out of alarm state if the pressure is below max and 30 seconds has elapsed. This is done because we don't think it's actually pumping for that long and may be entering alarm state unnecessarily. We need to get it working so this should safely allow the software to keep pumping, giving the pump 30 second rests if it's actually pumping for max pump time. Initial pressure values are also discarded because there is initial noise.