### PR TITLE
cmd: add sessionkeygen for generating session keys

### DIFF
--- a/cmd/sessionkeygen/main.go
+++ b/cmd/sessionkeygen/main.go
@@ -1,0 +1,40 @@
+/*
+AUTHORS
+
+	Trek Hopton <trek@ausocean.org>
+
+LICENSE
+
+	Copyright (C) 2025 the Australian Ocean Lab (AusOcean).
+
+	This is free software: you can redistribute it and/or modify it
+	under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This is distributed in the hope that it will be useful, but WITHOUT
+	ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+	or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+	License for more details.
+
+	You should have received a copy of the GNU General Public License in
+	gpl.txt. If not, see http://www.gnu.org/licenses/.
+*/
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"github.com/gorilla/securecookie"
+)
+
+func main() {
+	key := securecookie.GenerateRandomKey(32) // 256-bit key
+	if key == nil {
+		log.Fatal("Failed to generate session key")
+	}
+	fmt.Println("sessionKey:", base64.StdEncoding.EncodeToString(key))
+}


### PR DESCRIPTION
This was done to provide a simple utility for generating cloud service session keys. The key is 256 bit (32 bytes), encoded in base64 and printed to the console.

This is an alternative to doing it in a python interpreter:

```
import os
import binascii
binascii.hexlify(os.urandom(32))
```